### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "prepublishOnly": "nr build",
     "release": "bumpp && npm publish",
     "start": "esno src/index.ts",
-    "test": "vitest",
+    "test": "FORCE_COLOR=3 vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "picocolors": "^1.0.0"
+    "ansis": "^3.12.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,10 +8,10 @@ importers:
       '@antfu/ni': ^0.16.2
       '@antfu/utils': ^0.5.2
       '@types/node': ^18.0.0
+      ansis: ^3.12.0
       bumpp: ^8.2.1
       eslint: ^8.18.0
       esno: ^0.16.3
-      picocolors: ^1.0.0
       pnpm: ^7.2.1
       rimraf: ^3.0.2
       typescript: ^4.7.4
@@ -19,7 +19,7 @@ importers:
       vite: ^2.9.12
       vitest: ^0.15.1
     dependencies:
-      picocolors: 1.0.0
+      ansis: 3.12.0
     devDependencies:
       '@antfu/eslint-config': 0.25.1_b5e7v2qnwxfo6hmiq56u52mz3e
       '@antfu/ni': 0.16.2
@@ -759,6 +759,11 @@ packages:
     dependencies:
       color-convert: 2.0.1
     dev: true
+
+  /ansis/3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
+    dev: false
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2905,6 +2910,7 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
 
   /picomatch/2.3.0:
     resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}

--- a/src/construct.ts
+++ b/src/construct.ts
@@ -1,4 +1,4 @@
-import pc from 'picocolors'
+import ansis from 'ansis'
 import { toArray } from '@antfu/utils'
 import type { AnsiItem, AnsiObject, BuiltinColors } from './types'
 
@@ -70,7 +70,7 @@ function stringifyItem(item: AnsiObject) {
   if (item.color) {
     const colors = toArray(item.color).reverse()
     colors.forEach((c) => {
-      text = pc[c](text)
+      text = ansis[c](text)
     })
   }
   return text

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,4 +6,4 @@ export function newline(length = 1): string {
   return '\n'.repeat(length)
 }
 
-export { default as colors } from 'picocolors'
+export { default as colors } from 'ansis'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).

### Test

`pnpm test`

Outputs:
![image](https://github.com/user-attachments/assets/47c52741-aa81-49b2-9c57-5318f65b95c3)


